### PR TITLE
feat(download): generate short live token to download files

### DIFF
--- a/src/api/download.js
+++ b/src/api/download.js
@@ -1,0 +1,45 @@
+import Promise from 'bluebird'
+
+import Boom from 'boom'
+import Joi from 'joi'
+import path from 'path'
+
+import { torrentService } from '../torrents/TorrentService'
+
+const jwt = Promise.promisifyAll(require('jsonwebtoken'))
+
+export const download = {
+  method: 'GET',
+  path: '/download/{token}',
+  config: {
+    auth: false,
+    validate: {
+      params: {
+        token: Joi.string().required()
+      }
+    }
+  },
+  handler: async (request, reply) => {
+    try {
+      const decoded = await jwt.verify(request.params.token, 'secret')
+
+      try {
+        const { hashString, fileIndex } = decoded
+        const torrentStats = await torrentService.loadTorrentStats(hashString)
+
+        if (typeof torrentStats[fileIndex] !== 'undefined') {
+          const filePath = path.join(torrentStats.downloadDir, torrentStats.files[fileIndex].name)
+          reply.file(filePath, { mode: 'attachment', etagMethod: false })
+        } else {
+          reply(Boom.notFound())
+        }
+      } catch (ex) {
+        reply(ex)
+      }
+    } catch (ex) {
+      reply(Boom.unauthorized())
+    }
+  }
+}
+
+export default download

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,8 +1,10 @@
 import auth from './auth'
+import download from './download'
 import torrents from './torrents'
 
 function register (server, options, next) {
   server.route(auth)
+  server.route(download)
   server.route(torrents)
 
   next()

--- a/src/api/torrents.js
+++ b/src/api/torrents.js
@@ -1,9 +1,12 @@
+import Promise from 'bluebird'
+
 import Boom from 'boom'
 import Joi from 'joi'
-import path from 'path'
 
 import { torrentRepository } from '../torrents/TorrentRepository'
 import { torrentService } from '../torrents/TorrentService'
+
+const jwt = Promise.promisifyAll(require('jsonwebtoken'))
 
 const list = {
   method: 'GET',
@@ -92,27 +95,27 @@ const get = {
   }
 }
 
-const download = {
+const getToken = {
   method: 'GET',
-  path: '/torrents/{torrentId}/download/{fileIndex?}',
+  path: '/torrents/{torrentId}/files/{fileIndex}/token',
   config: {
     validate: {
       params: {
         torrentId: Joi.number().required(),
-        fileIndex: Joi.number()
+        fileIndex: Joi.number().required()
       }
     }
   },
   handler: async (request, reply) => {
     try {
-      const fileIndex = request.params.fileIndex || 0
+      const { torrentId, fileIndex } = request.params
 
-      const torrentModel = await torrentRepository.get(request.params.torrentId)
+      const torrentModel = await torrentRepository.get(torrentId)
       const torrentStats = await torrentService.loadTorrentStats(torrentModel.hashString)
 
-      if (typeof torrentStats[fileIndex] !== 'undefined') {
-        const filePath = path.join(torrentStats.downloadDir, torrentStats.files[fileIndex].name)
-        reply.file(filePath, { mode: 'attachment', etagMethod: false })
+      if (typeof torrentStats.files[fileIndex] !== 'undefined') {
+        const payload = { hashString: torrentModel.hashString, fileIndex }
+        reply({ token: await jwt.sign(payload, 'secret', { expiresIn: '24h' }) })
       } else {
         reply(Boom.notFound())
       }
@@ -122,4 +125,4 @@ const download = {
   }
 }
 
-export default [list, create, get, download]
+export default [list, create, get, getToken]


### PR DESCRIPTION
- Replaced the current download endpoint with a new one that generate
  a temporary link using JWT
- Added a new download endpoint that is now public, but take a JWT as
  url parameter
